### PR TITLE
Include the webcomponentsjs in build

### DIFF
--- a/gulp/polymer.json
+++ b/gulp/polymer.json
@@ -21,7 +21,8 @@
     "manifest.json",
     "favicon.ico",
     "robots.txt",
-    "bower_components/webcomponentsjs/webcomponents-loader.js"
+    "bower_components/webcomponentsjs/webcomponents-*.js",
+    "bower_components/webcomponentsjs/custom-elements-es5-adapter.js"
   ],
   "lint": {
     "rules": ["polymer-2"]


### PR DESCRIPTION
Fixes #38 

This PR includes all webcomponentsjs files in the build, required by the loader.js

Please test by running it with Docker