### PR TITLE
Fix importing of pages correctly

### DIFF
--- a/gulp/polymer.json
+++ b/gulp/polymer.json
@@ -12,6 +12,8 @@
     "src/lancie-admin-endpoint/lancie-admin-pages/lancie-admin-users.html",
     "src/lancie-admin-endpoint/lancie-admin-pages/lancie-admin-types.html",
     "src/lancie-admin-endpoint/lancie-admin-pages/lancie-admin-seats.html",
+    "src/lancie-admin-endpoint/lancie-admin-pages/lancie-admin-mail/lancie-admin-mail.html",
+    "src/lancie-admin-endpoint/lancie-admin-pages/lancie-admin-homepage-text.html",
     "src/lancie-admin-rfid/lancie-admin-rfid-assign.html",
     "src/lancie-admin-rfid/lancie-admin-rfid-alcohol.html",
     "src/lancie-admin-rfid/lancie-admin-rfid-consumption.html",

--- a/src/lancie-admin-content.html
+++ b/src/lancie-admin-content.html
@@ -3,20 +3,6 @@
 <link rel="import" href="../bower_components/app-route/app-route.html">
 <link rel="import" href="../bower_components/iron-lazy-pages/iron-lazy-pages.html">
 
-<link rel="import" href="./lancie-admin-404.html">
-<link rel="import" href="./lancie-admin-home/lancie-admin-home.html">
-<link rel="import" href="./lancie-admin-endpoint/lancie-admin-pages/lancie-admin-users.html">
-<link rel="import" href="./lancie-admin-endpoint/lancie-admin-pages/lancie-admin-teams.html">
-<link rel="import" href="./lancie-admin-endpoint/lancie-admin-pages/lancie-admin-orders.html">
-<link rel="import" href="./lancie-admin-endpoint/lancie-admin-pages/lancie-admin-teams.html">
-<link rel="import" href="./lancie-admin-endpoint/lancie-admin-pages/lancie-admin-tickets.html">
-<link rel="import" href="./lancie-admin-endpoint/lancie-admin-pages/lancie-admin-seats.html">
-<link rel="import" href="./lancie-admin-endpoint/lancie-admin-pages/lancie-admin-types.html">
-<link rel="import" href="./lancie-admin-endpoint/lancie-admin-pages/lancie-admin-homepage-text.html">
-<link rel="import" href="./lancie-admin-rfid/lancie-admin-rfid-assign.html">
-<link rel="import" href="./lancie-admin-rfid/lancie-admin-rfid-alcohol.html">
-<link rel="import" href="./lancie-admin-rfid/lancie-admin-rfid-consumption.html">
-
 <dom-module id="lancie-admin-content">
   <template>
     <style>


### PR DESCRIPTION
We keep forgetting this when we add pages. Importing is done this way. If you add a lazy-loaded page, the page should be added in `fragments` in the `polymer.json`, not in the content. If the page is not even imported, the entire site crashes in firefox. In chrome the specific page simply doesn't work.