### PR TITLE
Remove slash in api call

### DIFF
--- a/src/lancie-admin-endpoint/lancie-admin-pages/lancie-admin-seats/lancie-admin-seats.html
+++ b/src/lancie-admin-endpoint/lancie-admin-pages/lancie-admin-seats/lancie-admin-seats.html
@@ -436,7 +436,7 @@
               this.$.editSeatError.setError("That ticket does not exist, choose a different one!");
               return;
             }
-            this.$.ajaxAssignSeat.refurl = `/seats/${seat.seatGroup}/${seat.seatNumber}/${ticketID}`;
+            this.$.ajaxAssignSeat.refurl = `seats/${seat.seatGroup}/${seat.seatNumber}/${ticketID}`;
             this.$.ajaxAssignSeat.generateRequest();
           }
 


### PR DESCRIPTION
This change wasn't needed in the local space, but it did not work before on the live server.